### PR TITLE
[footnote-reference-popover] Fixed incorrect attribute specification for `<dialog>` elements

### DIFF
--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -23,7 +23,7 @@
 <script type="importmap">
   {
     "imports": {
-      "@w0s/footnote-reference-popover": "./dist/FootnoteReferencePopover.js"
+      "@w0s/footnote-reference-popover": "..."
     }
   }
 </script>

--- a/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
@@ -171,7 +171,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('data-popover-label', () => {
@@ -191,7 +191,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-label="Label" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" aria-label="Label" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" aria-label="Label" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('data-popover-class', () => {
@@ -211,7 +211,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-class="class" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" class="class" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" class="class" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('data-popover-close-text', () => {
@@ -231,7 +231,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Popover close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Popover close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('data-popover-close-image-src', () => {
@@ -251,7 +251,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button><img src="close.svg" alt="Close"></button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button><img src="close.svg" alt="Close"></button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('data-popover-mouse*-delay', () => {
@@ -271,7 +271,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('id arribute delete', () => {
@@ -291,7 +291,7 @@ describe('click event', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"><span id="foo">foo</span></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><span>foo</span><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><span>foo</span><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 });
 
@@ -321,7 +321,7 @@ describe('popover hide', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
 <p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('dialog close event', () => {
@@ -330,7 +330,7 @@ describe('popover hide', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
 <p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 });
 
@@ -367,7 +367,7 @@ describe('mouse', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('mouseleave', async () => {
@@ -376,7 +376,7 @@ describe('mouse', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 
 	test('hide', async () => {
@@ -385,7 +385,7 @@ describe('mouse', () => {
 		expect(document.body.innerHTML).toBe(`
 <a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
 <p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" tabindex="0" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
 	});
 });
 

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -144,7 +144,6 @@ export default class {
         if (this.#popoverClass !== undefined) {
             popoverElement.className = this.#popoverClass;
         }
-        popoverElement.tabIndex = 0;
         if (this.#popoverLabel !== undefined) {
             popoverElement.setAttribute('aria-label', this.#popoverLabel);
         }

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -141,6 +141,7 @@ export default class {
         document.body.appendChild(popoverWrapElement);
         const popoverElement = this.#popoverElement;
         popoverElement.id = this.#popoverId;
+        popoverElement.autofocus = true;
         if (this.#popoverClass !== undefined) {
             popoverElement.className = this.#popoverClass;
         }

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -8,14 +8,14 @@ export default class {
     #popoverWrapElement;
     #popoverElement;
     #popoverIdPrefix = 'popover-'; // ポップオーバーに設定する ID の接頭辞
-    #mouseenterTimeoutId; // ポップオーバーを表示する際のタイマーの識別 ID（clearTimeout() で使用）
-    #mouseleaveTimeoutId; // ポップオーバーを非表示にする際のタイマーの識別 ID（clearTimeout() で使用）
     #popoverLabel; // ポップオーバーに設定するラベル
     #popoverClass; // ポップオーバーに設定するクラス名
     #popoverCloseText = 'Close'; // ポップオーバーの閉じるボタンのテキスト
     #popoverCloseImageSrc; // ポップオーバーの閉じるボタンの画像パス
     #popoverMouseenterDelay = 250; // mouseenter 時にポップオーバーを表示する遅延時間（ミリ秒）
     #popoverMouseleaveDelay = 250; // mouseleave 時にポップオーバーを非表示にする遅延時間（ミリ秒）
+    #mouseenterTimeoutId; // ポップオーバーを表示する際のタイマーの識別 ID（clearTimeout() で使用）
+    #mouseleaveTimeoutId; // ポップオーバーを非表示にする際のタイマーの識別 ID（clearTimeout() で使用）
     #popoverCloseEventListener;
     #popoverKeydownEventListener;
     /**
@@ -202,34 +202,32 @@ export default class {
      * @param options.focus - ポップオーバーにフォーカスを行うか
      */
     #show(options = { focus: false }) {
-        if (!this.#popoverElement.isConnected) {
+        const popoverElement = this.#popoverElement;
+        if (!popoverElement.isConnected) {
             /* 初回表示時はポップオーバーの生成を行う */
             this.#create();
         }
-        const popoverElement = this.#popoverElement;
-        this.#popoverTriggerElement.setAttribute('aria-expanded', 'true');
-        /* 表示位置を設定する */
         const triggerRect = this.#popoverTriggerElement.getBoundingClientRect();
         /* ポップオーバーの上位置を設定（トリガー要素の下端を基準にする） */
         popoverElement.style.top = `${String(Math.round(triggerRect.bottom) + window.pageYOffset)}px`;
-        popoverElement.show();
+        /* ポップオーバーを表示 */
         this.#popoverWrapElement.hidden = false;
+        popoverElement.show();
+        if (options.focus) {
+            popoverElement.focus(); // TODO: 将来的には show() のパラメーターで指定できるようになる? https://github.com/whatwg/html/wiki/dialog--initial-focus,-a-proposal#initial-dialog-focus-logic
+        }
         document.addEventListener('keydown', this.#popoverKeydownEventListener);
+        this.#popoverTriggerElement.setAttribute('aria-expanded', 'true');
+        /* ポップオーバーの左右位置を設定（トリガー要素の左端を基準にする） */
         const documentWidth = document.documentElement.offsetWidth;
         const popoverWidth = popoverElement.getBoundingClientRect().width;
-        /* ポップオーバーの左右位置を設定（トリガー要素の左端を基準にする） */
-        /* いったんリセット */
         popoverElement.style.left = 'auto';
         popoverElement.style.right = 'auto';
-        /* 設定 */
         if (documentWidth - triggerRect.left < popoverWidth) {
             popoverElement.style.right = '0';
         }
         else {
             popoverElement.style.left = `${String(Math.round(triggerRect.left))}px`;
-        }
-        if (options.focus) {
-            popoverElement.focus(); // TODO: 将来的には show() のパラメーターで指定できるようになる? https://github.com/whatwg/html/wiki/dialog--initial-focus,-a-proposal#initial-dialog-focus-logic
         }
     }
 }

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -14,10 +14,6 @@ export default class {
 
 	readonly #popoverIdPrefix = 'popover-'; // ポップオーバーに設定する ID の接頭辞
 
-	#mouseenterTimeoutId?: NodeJS.Timeout; // ポップオーバーを表示する際のタイマーの識別 ID（clearTimeout() で使用）
-
-	#mouseleaveTimeoutId?: NodeJS.Timeout; // ポップオーバーを非表示にする際のタイマーの識別 ID（clearTimeout() で使用）
-
 	readonly #popoverLabel: string | undefined; // ポップオーバーに設定するラベル
 
 	readonly #popoverClass: string | undefined; // ポップオーバーに設定するクラス名
@@ -29,6 +25,10 @@ export default class {
 	readonly #popoverMouseenterDelay: number = 250; // mouseenter 時にポップオーバーを表示する遅延時間（ミリ秒）
 
 	readonly #popoverMouseleaveDelay: number = 250; // mouseleave 時にポップオーバーを非表示にする遅延時間（ミリ秒）
+
+	#mouseenterTimeoutId?: NodeJS.Timeout; // ポップオーバーを表示する際のタイマーの識別 ID（clearTimeout() で使用）
+
+	#mouseleaveTimeoutId?: NodeJS.Timeout; // ポップオーバーを非表示にする際のタイマーの識別 ID（clearTimeout() で使用）
 
 	readonly #popoverCloseEventListener: () => void;
 
@@ -268,42 +268,40 @@ export default class {
 	 * @param options.focus - ポップオーバーにフォーカスを行うか
 	 */
 	#show(options: { focus: boolean } = { focus: false }): void {
-		if (!this.#popoverElement.isConnected) {
+		const popoverElement = this.#popoverElement;
+		if (!popoverElement.isConnected) {
 			/* 初回表示時はポップオーバーの生成を行う */
 			this.#create();
 		}
 
-		const popoverElement = this.#popoverElement;
-
-		this.#popoverTriggerElement.setAttribute('aria-expanded', 'true');
-
-		/* 表示位置を設定する */
 		const triggerRect = this.#popoverTriggerElement.getBoundingClientRect();
 
 		/* ポップオーバーの上位置を設定（トリガー要素の下端を基準にする） */
 		popoverElement.style.top = `${String(Math.round(triggerRect.bottom) + window.pageYOffset)}px`;
 
-		popoverElement.show();
+		/* ポップオーバーを表示 */
 		this.#popoverWrapElement.hidden = false;
+
+		popoverElement.show();
+		if (options.focus) {
+			popoverElement.focus(); // TODO: 将来的には show() のパラメーターで指定できるようになる? https://github.com/whatwg/html/wiki/dialog--initial-focus,-a-proposal#initial-dialog-focus-logic
+		}
+
 		document.addEventListener('keydown', this.#popoverKeydownEventListener);
 
+		this.#popoverTriggerElement.setAttribute('aria-expanded', 'true');
+
+		/* ポップオーバーの左右位置を設定（トリガー要素の左端を基準にする） */
 		const documentWidth = document.documentElement.offsetWidth;
 		const popoverWidth = popoverElement.getBoundingClientRect().width;
 
-		/* ポップオーバーの左右位置を設定（トリガー要素の左端を基準にする） */
-		/* いったんリセット */
 		popoverElement.style.left = 'auto';
 		popoverElement.style.right = 'auto';
 
-		/* 設定 */
 		if (documentWidth - triggerRect.left < popoverWidth) {
 			popoverElement.style.right = '0';
 		} else {
 			popoverElement.style.left = `${String(Math.round(triggerRect.left))}px`;
-		}
-
-		if (options.focus) {
-			popoverElement.focus(); // TODO: 将来的には show() のパラメーターで指定できるようになる? https://github.com/whatwg/html/wiki/dialog--initial-focus,-a-proposal#initial-dialog-focus-logic
 		}
 	}
 }

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -188,7 +188,6 @@ export default class {
 		if (this.#popoverClass !== undefined) {
 			popoverElement.className = this.#popoverClass;
 		}
-		popoverElement.tabIndex = 0;
 		if (this.#popoverLabel !== undefined) {
 			popoverElement.setAttribute('aria-label', this.#popoverLabel);
 		}

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -185,6 +185,7 @@ export default class {
 
 		const popoverElement = this.#popoverElement;
 		popoverElement.id = this.#popoverId;
+		popoverElement.autofocus = true;
 		if (this.#popoverClass !== undefined) {
 			popoverElement.className = this.#popoverClass;
 		}


### PR DESCRIPTION
- <q>[The `tabindex` attribute must not be specified on `dialog` elements.](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)</q>
- Specify the `autofocus` attribute on the `<dialog>` element.
