### PR TITLE
[footnote-reference-popover] Changed `<x-popover>` custom element to use Shadow DOM

### DIFF
--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -85,15 +85,18 @@ The popover markup looks like this.
 >[1]</a>
 
 <x-popover class="my-popover">
-  ▼ #shadow-root
-    <span id="first-focusable" tabindex="0"></span>
-    <dialog part="popover" autofocus="">
-      <slot>...</slot>
-      <form method="dialog">
-        <button part="hide-button">Close</button>
-      </form>
-    </dialog>
-    <span id="last-focusable" tabindex="0"></span>
+  #shadow-root (open)
+  <span id="first-focusable" tabindex="0"></span>
+
+  <dialog part="popover" autofocus="">
+    <slot>...</slot>
+
+    <form method="dialog">
+      <button part="hide-button">Close</button>
+    </form>
+  </dialog>
+
+  <span id="last-focusable" tabindex="0"></span>
 </x-popover>
 ```
 

--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -43,8 +43,8 @@
   href="#footnote-2"
   data-popover-label="Note"
   data-popover-class="my-popover"
-  data-popover-close-text="Close"
-  data-popover-close-image-src="/assets/popover-close.svg"
+  data-popover-hide-text="Close"
+  data-popover-hide-image-src="/assets/popover-close.svg"
   data-mouseenter-delay="250"
   data-mouseleave-delay="250"
 >[1]</a>
@@ -64,9 +64,9 @@
 <dd>Label to be set on popover (<code>aria-label</code> attribute value). It is not required, but should be set as much as possible. In WAI-ARIA 1.2, accessible name is required for <a href="https://www.w3.org/TR/wai-aria-1.2/#dialog"><code>dialog</code> role</a>.</dd>
 <dt><code>data-popover-class</code> [optional]</dt>
 <dd>Set the class name (<code>class</code> attribute value) on the <code>&lt;dialog&gt;</code> element of the popover. It is mainly used to customize the appearance with CSS.</dd>
-<dt><code>data-popover-close-text</code> [optional]</dt>
+<dt><code>data-popover-hide-text</code> [optional]</dt>
 <dd>The text of the close button in the popover. If omitted, the default value is 'Close'.</dd>
-<dt><code>data-popover-close-image-src</code> [optional]</dt>
+<dt><code>data-popover-hide-image-src</code> [optional]</dt>
 <dd>The address of the image resource for the close button in the popover. For non Data URLs, the specified path will be inserted in the <code>head</code> element as <code>&lt;link rel="preload" as="image"&gt;</code>.</dd>
 <dt><code>data-mouseenter-delay</code> [optional]</dt>
 <dd>Delay time between mouse cursor moved within the trigger element and showing the popover (milliseconds). If omitted, the default value is '250'.</dd>

--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -45,8 +45,8 @@
   data-popover-class="my-popover"
   data-popover-close-text="Close"
   data-popover-close-image-src="/assets/popover-close.svg"
-  data-popover-mouseenter-delay="250"
-  data-popover-mouseleave-delay="250"
+  data-mouseenter-delay="250"
+  data-mouseleave-delay="250"
 >[1]</a>
 
 <ul class="footnotes">
@@ -68,9 +68,9 @@
 <dd>The text of the close button in the popover. If omitted, the default value is 'Close'.</dd>
 <dt><code>data-popover-close-image-src</code> [optional]</dt>
 <dd>The address of the image resource for the close button in the popover. For non Data URLs, the specified path will be inserted in the <code>head</code> element as <code>&lt;link rel="preload" as="image"&gt;</code>.</dd>
-<dt><code>data-popover-mouseenter-delay</code> [optional]</dt>
+<dt><code>data-mouseenter-delay</code> [optional]</dt>
 <dd>Delay time between mouse cursor moved within the trigger element and showing the popover (milliseconds). If omitted, the default value is '250'.</dd>
-<dt><code>data-popover-mouseleave-delay</code> [optional]</dt>
+<dt><code>data-mouseleave-delay</code> [optional]</dt>
 <dd>Delay time between mouse cursor moved out of the trigger element or popover and closing the popover (milliseconds). If omitted, the default value is '250'.</dd>
 </dl>
 

--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -42,7 +42,7 @@
 <a class="js-footnote-reference-popover"
   href="#footnote-2"
   data-popover-label="Note"
-  data-popover-class="mypopover"
+  data-popover-class="my-popover"
   data-popover-close-text="Close"
   data-popover-close-image-src="/assets/popover-close.svg"
   data-popover-mouseenter-delay="250"
@@ -73,3 +73,38 @@
 <dt><code>data-popover-mouseleave-delay</code> [optional]</dt>
 <dd>Delay time between mouse cursor moved out of the trigger element or popover and closing the popover (milliseconds). If omitted, the default value is '250'.</dd>
 </dl>
+
+## Style customization
+
+The popover markup looks like this.
+
+```html
+<a class="js-footnote-reference-popover"
+  href="#footnote"
+  data-popover-class="my-popover"
+>[1]</a>
+
+<x-popover class="my-popover">
+  ▼ #shadow-root
+    <span id="first-focusable" tabindex="0"></span>
+    <dialog part="popover" autofocus="">
+      <slot>...</slot>
+      <form method="dialog">
+        <button part="hide-button">Close</button>
+      </form>
+    </dialog>
+    <span id="last-focusable" tabindex="0"></span>
+</x-popover>
+```
+
+Therefore, you can customize the style using [`::part`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) CSS pseudo-element.
+
+```css
+.my-popover::part(popover) {
+  ...
+}
+
+.my-popover::part(hide-button) {
+  ...
+}
+```

--- a/packages/footnote-reference-popover/__tests__/CustomElementPopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/CustomElementPopover.test.js
@@ -1,0 +1,130 @@
+import { describe, beforeAll, afterAll, afterEach, test, expect, jest } from '@jest/globals';
+import CustomElementPopover from '../dist/CustomElementPopover.js';
+
+customElements.define('x-popover', CustomElementPopover);
+
+beforeAll(() => {
+	HTMLDialogElement.prototype.close = jest.fn();
+	HTMLDialogElement.prototype.show = jest.fn();
+	HTMLDialogElement.prototype.showModal = jest.fn();
+}); // `jsdom` が `<dialog>` 要素をサポートするまでの暫定処理 https://github.com/jsdom/jsdom/issues/3294
+
+describe('connected & disconnected', () => {
+	beforeAll(() => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover>text</x-popover>');
+	});
+	afterAll(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('connected', () => {
+		expect(document.body.innerHTML).toBe('<x-popover hidden="">text</x-popover>');
+	});
+
+	test('disconnected', () => {
+		document.querySelector('x-popover')?.remove();
+	});
+});
+
+describe('attributeChanged', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('label', () => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover label="label">text</x-popover>');
+
+		expect(document.querySelector('x-popover').label).toBe('label');
+	});
+
+	test('hide-text', () => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover hide-text="hide">text</x-popover>');
+
+		expect(document.querySelector('x-popover').hideText).toBe('hide');
+	});
+
+	test('hide-image-src', () => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover hide-image-src="hide.svg">text</x-popover>');
+
+		const element = document.querySelector('x-popover');
+
+		expect(element.hideText).toBe('Close');
+		expect(element.hideImageSrc).toBe('hide.svg');
+	});
+});
+
+describe('slot', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('id remove', () => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover><span id="ID">text</span></x-popover>');
+
+		expect(document.body.innerHTML).toBe('<x-popover hidden=""><span>text</span></x-popover>');
+	});
+});
+
+describe('toggle event', () => {
+	beforeAll(() => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover>text</x-popover>');
+	});
+	afterAll(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('open', () => {
+		const element = document.querySelector('x-popover');
+		element.dispatchEvent(
+			new CustomEvent('toggle', {
+				detail: {
+					newState: 'open',
+				},
+			}),
+		);
+
+		expect(document.body.innerHTML).toBe('<x-popover>text</x-popover>');
+	});
+
+	test('close', () => {
+		const element = document.querySelector('x-popover');
+		element.dispatchEvent(
+			new CustomEvent('toggle', {
+				detail: {
+					newState: 'closed',
+				},
+			}),
+		);
+
+		expect(document.body.innerHTML).toBe('<x-popover hidden="">text</x-popover>');
+	});
+});
+
+describe('keydown event', () => {
+	beforeAll(() => {
+		document.body.insertAdjacentHTML('beforeend', '<x-popover>text</x-popover>');
+
+		document.querySelector('x-popover').dispatchEvent(
+			new CustomEvent('toggle', {
+				detail: {
+					newState: 'open',
+				},
+			}),
+		);
+	});
+	afterAll(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('A', () => {
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A' }));
+
+		expect(document.body.innerHTML).toBe('<x-popover>text</x-popover>');
+	});
+
+	test('Escape', () => {
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+		expect(document.body.innerHTML).toBe('<x-popover hidden="">text</x-popover>');
+	});
+});

--- a/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
@@ -92,11 +92,11 @@ describe('HTML', () => {
 `);
 	});
 
-	test('data-popover-close-text', () => {
+	test('data-popover-hide-text', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-text="Popover close"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -104,16 +104,16 @@ describe('HTML', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-text="Popover close" role="button"></a>
 <p id="footnote"></p>
 `);
 	});
 
-	test('data-popover-close-image-src', () => {
+	test('data-popover-hide-image-src', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -121,7 +121,7 @@ describe('HTML', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 `);
 	});
@@ -153,7 +153,7 @@ describe('HTML - image preload', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -161,7 +161,7 @@ describe('HTML - image preload', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.documentElement.innerHTML).toBe(`<head><link rel="preload" href="close.svg"></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -170,7 +170,7 @@ describe('HTML - image preload', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="data:image/svg+xml,base64,..."></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="data:image/svg+xml,base64,..."></a>
 <p id="footnote"></p>
 `,
 		);
@@ -178,7 +178,7 @@ describe('HTML - image preload', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.documentElement.innerHTML).toBe(`<head></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="data:image/svg+xml,base64,..." role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="data:image/svg+xml,base64,..." role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -193,7 +193,7 @@ describe('HTML - image preload', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -203,7 +203,7 @@ describe('HTML - image preload', () => {
 		expect(document.documentElement.innerHTML).toBe(`<head>
 <link><link rel="preload" href="close.svg">
 </head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -218,7 +218,7 @@ describe('HTML - image preload', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -228,7 +228,7 @@ describe('HTML - image preload', () => {
 		expect(document.documentElement.innerHTML).toBe(`<head>
 <link rel="preload" href="close.svg">
 </head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});

--- a/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterAll, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
+import { describe, beforeAll, afterAll, afterEach, test, expect, jest } from '@jest/globals';
 import FootnoteReferencePopover from '../dist/FootnoteReferencePopover.js';
 
 const sleep = (ms) =>
@@ -41,7 +41,7 @@ describe('HTML', () => {
 		}).toThrow('Element: #footnote can not found.');
 	});
 
-	test('success', () => {
+	test('required attributes only', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
@@ -53,7 +53,92 @@ describe('HTML', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
+<p id="footnote"></p>
+`);
+	});
+
+	test('data-popover-label', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-label="Label"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-label="Label" role="button"></a>
+<p id="footnote"></p>
+`);
+	});
+
+	test('data-popover-class', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-class="class"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-class="class" role="button"></a>
+<p id="footnote"></p>
+`);
+	});
+
+	test('data-popover-close-text', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close" role="button"></a>
+<p id="footnote"></p>
+`);
+	});
+
+	test('data-popover-close-image-src', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
+<p id="footnote"></p>
+`);
+	});
+
+	test('data-popover-mouse*-delay', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button"></a>
 <p id="footnote"></p>
 `);
 	});
@@ -76,7 +161,7 @@ describe('HTML - image preload', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.documentElement.innerHTML).toBe(`<head><link rel="preload" href="close.svg"></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -93,7 +178,7 @@ describe('HTML - image preload', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.documentElement.innerHTML).toBe(`<head></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="data:image/svg+xml,base64,..." role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="data:image/svg+xml,base64,..." role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -118,7 +203,7 @@ describe('HTML - image preload', () => {
 		expect(document.documentElement.innerHTML).toBe(`<head>
 <link><link rel="preload" href="close.svg">
 </head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -143,7 +228,7 @@ describe('HTML - image preload', () => {
 		expect(document.documentElement.innerHTML).toBe(`<head>
 <link rel="preload" href="close.svg">
 </head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button"></a>
 <p id="footnote"></p>
 </body>`);
 	});
@@ -154,47 +239,7 @@ describe('click event', () => {
 		document.documentElement.innerHTML = '';
 	});
 
-	test('Required attributes only', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover"></a>
-<p id="footnote"></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('data-popover-label', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-label="Label"></a>
-<p id="footnote"></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-label="Label" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" aria-label="Label" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('data-popover-class', () => {
+	test('click', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
@@ -209,132 +254,13 @@ describe('click event', () => {
 		element.dispatchEvent(new UIEvent('click'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-class="class" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-class="class" role="button"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" class="class" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('data-popover-close-text', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close"></a>
-<p id="footnote"></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-text="Popover close" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Popover close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('data-popover-close-image-src', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg"></a>
-<p id="footnote"></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-close-image-src="close.svg" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button><img src="close.svg" alt="Close"></button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('data-popover-mouse*-delay', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110"></a>
-<p id="footnote"></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('id arribute delete', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110"></a>
-<p id="footnote"><span id="foo">foo</span></p>
-`,
-		);
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
-<p id="footnote"><span id="foo">foo</span></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><span>foo</span><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover class="class" style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
 	});
 });
 
-describe('popover hide', () => {
-	beforeEach(() => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover"></a>
-<p id="footnote"></p>
-`,
-		);
-
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
-
-		element.dispatchEvent(new UIEvent('click'));
-	});
-	afterEach(() => {
-		document.documentElement.innerHTML = '';
-	});
-
-	test('Escape key', async () => {
-		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
-<p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-
-	test('dialog close event', () => {
-		document.querySelector('x-popover dialog').dispatchEvent(new Event('close'));
-
-		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
-<p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
-	});
-});
-
-describe('mouse', () => {
+describe('trigger mouse event', () => {
 	beforeAll(() => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
@@ -344,9 +270,7 @@ describe('mouse', () => {
 `,
 		);
 
-		const element = document.querySelector('.js-footnote-reference-popover');
-
-		new FootnoteReferencePopover(element);
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 	});
 	afterAll(() => {
 		document.documentElement.innerHTML = '';
@@ -356,7 +280,7 @@ describe('mouse', () => {
 		document.querySelector('.js-footnote-reference-popover').dispatchEvent(new MouseEvent('mouseenter'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
 <p id="footnote"></p>
 `);
 	});
@@ -365,30 +289,85 @@ describe('mouse', () => {
 		await sleep(500);
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
 	});
 
 	test('mouseleave', async () => {
 		document.querySelector('.js-footnote-reference-popover').dispatchEvent(new MouseEvent('mouseleave'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="true"></a>
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
 <p id="footnote"></p>
-<x-popover><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
 	});
 
 	test('hide', async () => {
 		await sleep(500);
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" role="button" aria-controls="popover-footnote" aria-expanded="false"></a>
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
 <p id="footnote"></p>
-<x-popover hidden=""><span tabindex="0"></span><dialog id="popover-footnote" style="top: 0px; left: 0px;"><form method="dialog"><button>Close</button></form></dialog><span tabindex="0"></span></x-popover>`);
+<x-popover style="width: 0px; top: 0px; left: 0px;" hidden=""></x-popover>`);
 	});
 });
 
-describe('focus', () => {
-	// TODO:
+describe('popover mouse event', () => {
+	beforeAll(() => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
+	});
+	afterAll(() => {
+		document.documentElement.innerHTML = '';
+	});
+
+	test('show', async () => {
+		document.querySelector('.js-footnote-reference-popover').dispatchEvent(new MouseEvent('mouseenter'));
+
+		await sleep(500);
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
+<p id="footnote"></p>
+<x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
+	});
+
+	test('mouseenter', async () => {
+		document.querySelector('.js-footnote-reference-popover').dispatchEvent(new MouseEvent('mouseleave'));
+
+		document.querySelector('x-popover').dispatchEvent(new MouseEvent('mouseenter'));
+
+		await sleep(500);
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
+<p id="footnote"></p>
+<x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
+	});
+
+	test('mouseleave', async () => {
+		document.querySelector('x-popover').dispatchEvent(new MouseEvent('mouseleave'));
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
+<p id="footnote"></p>
+<x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
+	});
+
+	test('hide', async () => {
+		await sleep(500);
+
+		expect(document.body.innerHTML).toBe(`
+<a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
+<p id="footnote"></p>
+<x-popover style="width: 0px; top: 0px; left: 0px;" hidden=""></x-popover>`);
+	});
 });

--- a/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
@@ -144,96 +144,6 @@ describe('HTML', () => {
 	});
 });
 
-describe('HTML - image preload', () => {
-	afterEach(() => {
-		document.documentElement.innerHTML = '';
-	});
-
-	test('no link element', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
-<p id="footnote"></p>
-`,
-		);
-
-		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
-
-		expect(document.documentElement.innerHTML).toBe(`<head><link rel="preload" href="close.svg"></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
-<p id="footnote"></p>
-</body>`);
-	});
-
-	test('data url', () => {
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="data:image/svg+xml,base64,..."></a>
-<p id="footnote"></p>
-`,
-		);
-
-		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
-
-		expect(document.documentElement.innerHTML).toBe(`<head></head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="data:image/svg+xml,base64,..." role="button"></a>
-<p id="footnote"></p>
-</body>`);
-	});
-
-	test('link element already exists', () => {
-		document.head.insertAdjacentHTML(
-			'beforeend',
-			`
-<link/>
-`,
-		);
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
-<p id="footnote"></p>
-`,
-		);
-
-		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
-
-		expect(document.documentElement.innerHTML).toBe(`<head>
-<link><link rel="preload" href="close.svg">
-</head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
-<p id="footnote"></p>
-</body>`);
-	});
-
-	test('link preload already exists', () => {
-		document.head.insertAdjacentHTML(
-			'beforeend',
-			`
-<link rel="preload" href="close.svg"/>
-`,
-		);
-		document.body.insertAdjacentHTML(
-			'beforeend',
-			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
-<p id="footnote"></p>
-`,
-		);
-
-		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
-
-		expect(document.documentElement.innerHTML).toBe(`<head>
-<link rel="preload" href="close.svg">
-</head><body>
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg" role="button"></a>
-<p id="footnote"></p>
-</body>`);
-	});
-});
-
 describe('click event', () => {
 	afterEach(() => {
 		document.documentElement.innerHTML = '';
@@ -294,7 +204,7 @@ describe('trigger mouse event', () => {
 <x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
 	});
 
-	test('mouseleave', async () => {
+	test('mouseleave', () => {
 		document.querySelector('.js-footnote-reference-popover').dispatchEvent(new MouseEvent('mouseleave'));
 
 		expect(document.body.innerHTML).toBe(`
@@ -353,7 +263,7 @@ describe('popover mouse event', () => {
 <x-popover style="width: 0px; top: 0px; left: 0px;"></x-popover>`);
 	});
 
-	test('mouseleave', async () => {
+	test('mouseleave', () => {
 		document.querySelector('x-popover').dispatchEvent(new MouseEvent('mouseleave'));
 
 		expect(document.body.innerHTML).toBe(`
@@ -369,5 +279,63 @@ describe('popover mouse event', () => {
 <a href="#footnote" class="js-footnote-reference-popover" role="button"></a>
 <p id="footnote"></p>
 <x-popover style="width: 0px; top: 0px; left: 0px;" hidden=""></x-popover>`);
+	});
+});
+
+describe('HTML - image preload', () => {
+	afterEach(() => {
+		document.documentElement.innerHTML = '';
+	});
+
+	test('no link element', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		const element = document.querySelector('.js-footnote-reference-popover');
+
+		new FootnoteReferencePopover(element);
+		element.dispatchEvent(new MouseEvent('mouseenter'));
+
+		expect(document.head.innerHTML).toBe('<link rel="preload" href="close.svg">'); // TODO: 本来は `as="image"` が付与される https://github.com/jsdom/jsdom/issues/3214
+	});
+
+	test('data url', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="data:image/svg+xml,base64,..."></a>
+<p id="footnote"></p>
+`,
+		);
+
+		const element = document.querySelector('.js-footnote-reference-popover');
+
+		new FootnoteReferencePopover(element);
+		element.dispatchEvent(new MouseEvent('mouseenter'));
+
+		expect(document.head.innerHTML).toBe('');
+	});
+
+	test('link element already exists', () => {
+		document.head.insertAdjacentHTML('beforeend', '<link/>');
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			`
+<a href="#footnote" class="js-footnote-reference-popover" data-popover-hide-image-src="close.svg"></a>
+<p id="footnote"></p>
+`,
+		);
+
+		const element = document.querySelector('.js-footnote-reference-popover');
+
+		new FootnoteReferencePopover(element);
+		element.dispatchEvent(new MouseEvent('mouseenter'));
+
+		expect(document.head.innerHTML).toBe('<link><link rel="preload" href="close.svg">'); // TODO: 本来は `as="image"` が付与される https://github.com/jsdom/jsdom/issues/3214
 	});
 });

--- a/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
+++ b/packages/footnote-reference-popover/__tests__/FootnoteReferencePopover.test.js
@@ -126,11 +126,11 @@ describe('HTML', () => {
 `);
 	});
 
-	test('data-popover-mouse*-delay', () => {
+	test('data-mouse*-delay', () => {
 		document.body.insertAdjacentHTML(
 			'beforeend',
 			`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-mouseenter-delay="100" data-mouseleave-delay="110"></a>
 <p id="footnote"></p>
 `,
 		);
@@ -138,7 +138,7 @@ describe('HTML', () => {
 		new FootnoteReferencePopover(document.querySelector('.js-footnote-reference-popover'));
 
 		expect(document.body.innerHTML).toBe(`
-<a href="#footnote" class="js-footnote-reference-popover" data-popover-mouseenter-delay="100" data-popover-mouseleave-delay="110" role="button"></a>
+<a href="#footnote" class="js-footnote-reference-popover" data-mouseenter-delay="100" data-mouseleave-delay="110" role="button"></a>
 <p id="footnote"></p>
 `);
 	});

--- a/packages/footnote-reference-popover/demo/index.html
+++ b/packages/footnote-reference-popover/demo/index.html
@@ -81,8 +81,8 @@
   href="#footnote-2"
   data-popover-label="Note"
   data-popover-class="my-popover"
-  data-popover-close-text="Popover Close"
-  data-popover-close-image-src="./popover-close.svg"
+  data-popover-hide-text="Popover Close"
+  data-popover-hide-image-src="./popover-close.svg"
   data-mouseenter-delay="1000"
   data-mouseleave-delay="1000"
 &gt;[2]&lt;/a&gt;</code></pre>
@@ -95,8 +95,8 @@
 						href="#footnote-2"
 						data-popover-label="Note"
 						data-popover-class="my-popover"
-						data-popover-close-text="Popover Close"
-						data-popover-close-image-src="./popover-close.svg"
+						data-popover-hide-text="Popover Close"
+						data-popover-hide-image-src="./popover-close.svg"
 						data-mouseenter-delay="1000"
 						data-mouseleave-delay="1000"
 						>[2]</a

--- a/packages/footnote-reference-popover/demo/index.html
+++ b/packages/footnote-reference-popover/demo/index.html
@@ -10,48 +10,39 @@
 				border-block-start: 1px solid #ccc;
 			}
 
-			.my-popover {
-				--popover-close-button-image-size: 36px;
-				--popover-close-button-padding: 10px;
+			.my-popover::part(popover) {
+				--popover-hide-button-image-size: 36px;
+				--popover-hide-button-padding: 10px;
 
 				border: 1px solid #666;
 				border-radius: 0.25em;
 				padding: 10px;
-				max-width: min(20em, 100%);
+				max-inline-size: min(20em, 100%);
 				color: #000;
 				background: #fff;
 				box-shadow: 0 0 5px #ccc;
 			}
 
-			.my-popover::before {
+			.my-popover::part(popover)::before {
 				float: right;
 				display: block;
-				width: calc(var(--popover-close-button-image-size) + var(--popover-close-button-padding) * 2);
-				height: calc(var(--popover-close-button-image-size) + var(--popover-close-button-padding) * 2);
+				inline-size: calc(var(--popover-hide-button-image-size) + var(--popover-hide-button-padding) * 2);
+				block-size: calc(var(--popover-hide-button-image-size) + var(--popover-hide-button-padding) * 2);
 				content: '';
 			}
 
-			.my-popover > form[method='dialog'] {
+			.my-popover::part(hide-button) {
 				position: absolute;
 				inset-block-start: 0;
 				inset-inline-end: 0;
-			}
-
-			.my-popover > form[method='dialog'] > button {
 				border: none;
 				border-radius: 0.25em;
-				padding: var(--popover-close-button-padding);
+				padding: var(--popover-hide-button-padding);
 				background: transparent;
 			}
 
-			.my-popover > form[method='dialog'] > button:hover {
-				background: #eee;
-			}
-
-			.my-popover > form[method='dialog'] > button > img {
-				display: block;
-				width: var(--popover-close-button-image-size);
-				height: var(--popover-close-button-image-size);
+			.my-popover::part(hide-button):hover {
+				background-color: #eee;
 			}
 		</style>
 		<script type="importmap">

--- a/packages/footnote-reference-popover/demo/index.html
+++ b/packages/footnote-reference-popover/demo/index.html
@@ -83,8 +83,8 @@
   data-popover-class="my-popover"
   data-popover-close-text="Popover Close"
   data-popover-close-image-src="./popover-close.svg"
-  data-popover-mouseenter-delay="1000"
-  data-popover-mouseleave-delay="1000"
+  data-mouseenter-delay="1000"
+  data-mouseleave-delay="1000"
 &gt;[2]&lt;/a&gt;</code></pre>
 
 			<p>
@@ -97,8 +97,8 @@
 						data-popover-class="my-popover"
 						data-popover-close-text="Popover Close"
 						data-popover-close-image-src="./popover-close.svg"
-						data-popover-mouseenter-delay="1000"
-						data-popover-mouseleave-delay="1000"
+						data-mouseenter-delay="1000"
+						data-mouseleave-delay="1000"
 						>[2]</a
 					></sup
 				>

--- a/packages/footnote-reference-popover/dist/CustomElementPopover.js
+++ b/packages/footnote-reference-popover/dist/CustomElementPopover.js
@@ -1,0 +1,193 @@
+/**
+ * Popover
+ */
+export default class CustomElementPopover extends HTMLElement {
+    #popoverElement;
+    #hideButtonElement;
+    #firstFocusableElement;
+    #lastFocusableElement;
+    #hideText = 'Close';
+    #hideImageSrc = null;
+    #toggleEventListener;
+    #keydownEventListener;
+    #firstFocusableFocusEventListener;
+    #lastFocusableFocusEventListener;
+    static get observedAttributes() {
+        return ['label', 'hide-text', 'hide-image-src'];
+    }
+    constructor() {
+        super();
+        const cssString = `
+			:host {
+				position: absolute;
+			}
+
+			[part="popover"] {
+				position: static;
+				contain: layout;
+				margin: 0;
+			}
+
+			[part="hide-button"] > img {
+				display: block;
+			}
+		`;
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+			<span id="first-focusable" tabindex="0"></span>
+			<dialog part="popover" autofocus="">
+				<slot></slot>
+				<form method="dialog">
+					<button part="hide-button"></button>
+				</form>
+			</dialog>
+			<span id="last-focusable" tabindex="0"></span>
+		`;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (shadow.adoptedStyleSheets !== undefined) {
+            const cssStyleSheet = new CSSStyleSheet();
+            cssStyleSheet.replaceSync(cssString);
+            shadow.adoptedStyleSheets = [cssStyleSheet];
+        }
+        else {
+            /* adoptedStyleSheets 未対応環境 */
+            shadow.innerHTML += `<style>${cssString}</style>`;
+        }
+        const shadowRoot = this.shadowRoot;
+        this.#popoverElement = shadowRoot.querySelector('[part="popover"]');
+        this.#hideButtonElement = shadowRoot.querySelector('[part="hide-button"]');
+        this.#firstFocusableElement = shadowRoot.getElementById('first-focusable');
+        this.#lastFocusableElement = shadowRoot.getElementById('last-focusable');
+        this.#hideButtonElement.textContent = this.#hideText;
+        this.#toggleEventListener = this.#toggleEvent.bind(this);
+        this.#keydownEventListener = this.#keydownEvent.bind(this);
+        this.#firstFocusableFocusEventListener = this.#firstFocusableFocusEvent.bind(this);
+        this.#lastFocusableFocusEventListener = this.#lastFocusableFocusEvent.bind(this);
+    }
+    connectedCallback() {
+        this.hidden = true;
+        /* コピー元の HTML 中に id 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
+        for (const element of this.shadowRoot.host.querySelectorAll('[id]')) {
+            element.removeAttribute('id');
+        }
+        /* ポップオーバー状態変化 */
+        this.addEventListener('toggle', this.#toggleEventListener, { passive: true });
+        /* 循環フォーカス */
+        this.#firstFocusableElement.addEventListener('focus', this.#firstFocusableFocusEventListener, { passive: true });
+        this.#lastFocusableElement.addEventListener('focus', this.#lastFocusableFocusEventListener, { passive: true });
+    }
+    disconnectedCallback() {
+        /* ポップオーバー状態変化 */
+        this.removeEventListener('toggle', this.#toggleEventListener);
+        /* 循環フォーカス */
+        this.#firstFocusableElement.removeEventListener('focus', this.#firstFocusableFocusEventListener);
+        this.#lastFocusableElement.removeEventListener('focus', this.#lastFocusableFocusEventListener);
+    }
+    attributeChangedCallback(name, _oldValue, newValue) {
+        switch (name) {
+            case 'label': {
+                this.label = newValue;
+                break;
+            }
+            case 'hide-text': {
+                this.hideText = newValue;
+                break;
+            }
+            case 'hide-image-src': {
+                this.hideImageSrc = newValue;
+                break;
+            }
+            default:
+        }
+    }
+    get label() {
+        return this.#popoverElement.ariaLabel;
+    }
+    set label(value) {
+        this.#popoverElement.ariaLabel = value;
+    }
+    get hideText() {
+        return this.#hideText;
+    }
+    set hideText(value) {
+        if (value === null) {
+            return;
+        }
+        this.#hideText = value;
+        this.#hideButtonElement.textContent = value;
+    }
+    get hideImageSrc() {
+        return this.#hideImageSrc;
+    }
+    set hideImageSrc(value) {
+        this.#hideImageSrc = value;
+        if (value === null) {
+            this.#hideButtonElement.textContent = this.#hideText;
+            return;
+        }
+        const newImageElement = document.createElement('img');
+        newImageElement.src = value;
+        newImageElement.alt = this.#hideText;
+        this.#hideButtonElement.textContent = '';
+        this.#hideButtonElement.appendChild(newImageElement);
+    }
+    get width() {
+        return this.#popoverElement.getBoundingClientRect().width;
+    }
+    /**
+     * ポップオーバーの表示／非表示状態が変化したの処理
+     *
+     * @param ev - CustomEvent
+     */
+    #toggleEvent(ev) {
+        switch (ev.detail.newState) {
+            case 'open': {
+                this.hidden = false;
+                this.#popoverElement.show();
+                document.addEventListener('keydown', this.#keydownEventListener);
+                break;
+            }
+            case 'closed': {
+                this.hidden = true;
+                this.#popoverElement.close();
+                document.removeEventListener('keydown', this.#keydownEventListener);
+                break;
+            }
+            default: {
+                throw new Error('The value of `newState` must be either `open` or `closed`.');
+            }
+        }
+    }
+    /**
+     * popover `keydown` event
+     *
+     * @param ev - KeyboardEvent
+     */
+    #keydownEvent(ev) {
+        switch (ev.key) {
+            case 'Escape': {
+                ev.preventDefault();
+                this.dispatchEvent(new CustomEvent('toggle', {
+                    detail: {
+                        newState: 'closed',
+                    },
+                }));
+                break;
+            }
+            default:
+        }
+    }
+    /**
+     * 最初の循環フォーカス要素にフォーカスされたときの処理
+     */
+    #firstFocusableFocusEvent() {
+        this.#hideButtonElement.focus();
+    }
+    /**
+     * 最後の循環フォーカス要素にフォーカスされたときの処理
+     */
+    #lastFocusableFocusEvent() {
+        this.#popoverElement.focus();
+    }
+}
+//# sourceMappingURL=CustomElementPopover.js.map

--- a/packages/footnote-reference-popover/dist/CustomElementPopover.js
+++ b/packages/footnote-reference-popover/dist/CustomElementPopover.js
@@ -53,11 +53,10 @@ export default class CustomElementPopover extends HTMLElement {
             /* adoptedStyleSheets 未対応環境 */
             shadow.innerHTML += `<style>${cssString}</style>`;
         }
-        const shadowRoot = this.shadowRoot;
-        this.#popoverElement = shadowRoot.querySelector('[part="popover"]');
-        this.#hideButtonElement = shadowRoot.querySelector('[part="hide-button"]');
-        this.#firstFocusableElement = shadowRoot.getElementById('first-focusable');
-        this.#lastFocusableElement = shadowRoot.getElementById('last-focusable');
+        this.#popoverElement = shadow.querySelector('[part="popover"]');
+        this.#hideButtonElement = shadow.querySelector('[part="hide-button"]');
+        this.#firstFocusableElement = shadow.getElementById('first-focusable');
+        this.#lastFocusableElement = shadow.getElementById('last-focusable');
         this.#hideButtonElement.textContent = this.#hideText;
         this.#toggleEventListener = this.#toggleEvent.bind(this);
         this.#keydownEventListener = this.#keydownEvent.bind(this);
@@ -67,8 +66,11 @@ export default class CustomElementPopover extends HTMLElement {
     connectedCallback() {
         this.hidden = true;
         /* コピー元の HTML 中に id 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
-        for (const element of this.shadowRoot.host.querySelectorAll('[id]')) {
-            element.removeAttribute('id');
+        const hostElement = this.shadowRoot?.host;
+        if (hostElement !== undefined) {
+            for (const element of hostElement.querySelectorAll('[id]')) {
+                element.removeAttribute('id');
+            }
         }
         /* ポップオーバー状態変化 */
         this.addEventListener('toggle', this.#toggleEventListener, { passive: true });

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -1,30 +1,27 @@
+import HTMLPopoverElement from './CustomElementPopover.js';
+customElements.define('x-popover', HTMLPopoverElement);
 /**
  * Footnote reference popover
  */
 export default class {
     #popoverTriggerElement;
     #footnoteElement; // 脚注要素（ポップオーバーの内容をここからコピーする）
-    #popoverId;
-    #popoverWrapElement;
     #popoverElement;
-    #popoverIdPrefix = 'popover-'; // ポップオーバーに設定する ID の接頭辞
     #popoverLabel; // ポップオーバーに設定するラベル
     #popoverClass; // ポップオーバーに設定するクラス名
-    #popoverCloseText = 'Close'; // ポップオーバーの閉じるボタンのテキスト
-    #popoverCloseImageSrc; // ポップオーバーの閉じるボタンの画像パス
-    #popoverMouseenterDelay = 250; // mouseenter 時にポップオーバーを表示する遅延時間（ミリ秒）
-    #popoverMouseleaveDelay = 250; // mouseleave 時にポップオーバーを非表示にする遅延時間（ミリ秒）
-    #mouseenterTimeoutId; // ポップオーバーを表示する際のタイマーの識別 ID（clearTimeout() で使用）
-    #mouseleaveTimeoutId; // ポップオーバーを非表示にする際のタイマーの識別 ID（clearTimeout() で使用）
-    #popoverCloseEventListener;
-    #popoverKeydownEventListener;
+    #popoverHideText; // ポップオーバーの閉じるボタンのテキスト
+    #popoverHideImageSrc; // ポップオーバーの閉じるボタンの画像パス
+    #mouseenterDelay = 250; // mouseenter 時にポップオーバーを表示する遅延時間（ミリ秒）
+    #mouseleaveDelay = 250; // mouseleave 時にポップオーバーを非表示にする遅延時間（ミリ秒）
+    #mouseenterTimeoutId; // ポップオーバーを表示する際のタイマーの識別 ID（`clearTimeout()` で使用）
+    #mouseleaveTimeoutId; // ポップオーバーを非表示にする際のタイマーの識別 ID（`clearTimeout()` で使用）
     /**
      * @param thisElement - Target element
      */
     constructor(thisElement) {
         this.#popoverTriggerElement = thisElement;
         const { href } = thisElement;
-        const { popoverLabel, popoverClass, popoverCloseText, popoverCloseImageSrc, popoverMouseenterDelay, popoverMouseleaveDelay } = thisElement.dataset;
+        const { popoverLabel, popoverClass, popoverCloseText: popoverHideText, popoverCloseImageSrc: popoverHideImageSrc, popoverMouseenterDelay: mouseenterDelay, popoverMouseleaveDelay: mouseleaveDelay, } = thisElement.dataset;
         if (href === '') {
             throw new Error('Attribute: `href` is not set.');
         }
@@ -38,37 +35,29 @@ export default class {
             throw new Error(`Element: #${footnoteId} can not found.`);
         }
         this.#footnoteElement = footnoteElement;
-        this.#popoverId = `${this.#popoverIdPrefix}${footnoteId}`;
         this.#popoverLabel = popoverLabel;
         this.#popoverClass = popoverClass;
-        if (popoverCloseText !== undefined) {
-            this.#popoverCloseText = popoverCloseText;
+        this.#popoverHideText = popoverHideText;
+        this.#popoverHideImageSrc = popoverHideImageSrc;
+        if (mouseenterDelay !== undefined) {
+            this.#mouseenterDelay = Number(mouseenterDelay);
         }
-        this.#popoverCloseImageSrc = popoverCloseImageSrc;
-        if (popoverMouseenterDelay !== undefined) {
-            this.#popoverMouseenterDelay = Number(popoverMouseenterDelay);
+        if (mouseleaveDelay !== undefined) {
+            this.#mouseleaveDelay = Number(mouseleaveDelay);
         }
-        if (popoverMouseleaveDelay !== undefined) {
-            this.#popoverMouseleaveDelay = Number(popoverMouseleaveDelay);
-        }
-        this.#popoverWrapElement = document.createElement('x-popover');
-        this.#popoverElement = document.createElement('dialog');
+        this.#popoverElement = document.createElement('x-popover');
         thisElement.setAttribute('role', 'button');
-        thisElement.setAttribute('aria-controls', this.#popoverId);
-        thisElement.setAttribute('aria-expanded', 'false');
+        thisElement.addEventListener('click', this.#clickEvent);
         thisElement.addEventListener('mouseenter', this.#mouseEnterEvent, { passive: true });
         thisElement.addEventListener('mouseleave', this.#mouseLeaveEvent, { passive: true });
-        thisElement.addEventListener('click', this.#clickEvent);
-        this.#popoverCloseEventListener = this.#popoverCloseEvent.bind(this);
-        this.#popoverKeydownEventListener = this.#popoverKeydownEvent.bind(this);
         /* Image preload */
-        if (popoverCloseImageSrc !== undefined &&
-            !popoverCloseImageSrc.trimStart().startsWith('data:') &&
-            document.querySelector(`link[rel="preload"][href="${popoverCloseImageSrc}"]`) === null) {
+        if (popoverHideImageSrc !== undefined &&
+            !popoverHideImageSrc.trimStart().startsWith('data:') &&
+            document.querySelector(`link[rel="preload"][href="${popoverHideImageSrc}"]`) === null) {
             const preloadElement = document.createElement('link');
             preloadElement.rel = 'preload';
             preloadElement.as = 'image';
-            preloadElement.href = popoverCloseImageSrc;
+            preloadElement.href = popoverHideImageSrc;
             const alreadyHeadLinkElements = document.head.querySelectorAll('link');
             if (alreadyHeadLinkElements.length === 0) {
                 document.head.appendChild(preloadElement);
@@ -79,13 +68,23 @@ export default class {
         }
     }
     /**
+     * `click` event
+     *
+     * @param ev - MouseEvent
+     */
+    #clickEvent = (ev) => {
+        ev.preventDefault();
+        clearTimeout(this.#mouseleaveTimeoutId);
+        this.#show();
+    };
+    /**
      * `mouseenter` event
      */
     #mouseEnterEvent = () => {
         clearTimeout(this.#mouseleaveTimeoutId);
         this.#mouseenterTimeoutId = setTimeout(() => {
             this.#show();
-        }, this.#popoverMouseenterDelay);
+        }, this.#mouseenterDelay);
     };
     /**
      * `mouseleave` event
@@ -93,115 +92,39 @@ export default class {
     #mouseLeaveEvent = () => {
         clearTimeout(this.#mouseenterTimeoutId);
         this.#mouseleaveTimeoutId = setTimeout(() => {
-            this.#popoverElement.dispatchEvent(new Event('close'));
-        }, this.#popoverMouseleaveDelay);
+            this.#hide();
+        }, this.#mouseleaveDelay);
     };
-    /**
-     * `click` event
-     *
-     * @param ev - MouseEvent
-     */
-    #clickEvent = (ev) => {
-        clearTimeout(this.#mouseleaveTimeoutId);
-        this.#show({
-            focus: true,
-        });
-        ev.preventDefault();
-    };
-    /**
-     * popover `close` event
-     */
-    #popoverCloseEvent() {
-        this.#popoverTriggerElement.setAttribute('aria-expanded', 'false');
-        this.#popoverWrapElement.hidden = true;
-        document.removeEventListener('keydown', this.#popoverKeydownEventListener);
-    }
-    /**
-     * popover `keydown` event
-     *
-     * @param ev - KeyboardEvent
-     */
-    #popoverKeydownEvent(ev) {
-        switch (ev.key) {
-            case 'Escape': {
-                ev.preventDefault();
-                clearTimeout(this.#mouseenterTimeoutId);
-                this.#popoverElement.dispatchEvent(new Event('close'));
-                break;
-            }
-            default:
-        }
-    }
     /**
      * ポップオーバーを生成する
      */
     #create() {
-        const popoverWrapElement = this.#popoverWrapElement;
-        popoverWrapElement.hidden = true;
-        document.body.appendChild(popoverWrapElement);
         const popoverElement = this.#popoverElement;
-        popoverElement.id = this.#popoverId;
-        popoverElement.autofocus = true;
         if (this.#popoverClass !== undefined) {
             popoverElement.className = this.#popoverClass;
         }
-        if (this.#popoverLabel !== undefined) {
-            popoverElement.setAttribute('aria-label', this.#popoverLabel);
-        }
+        popoverElement.label = this.#popoverLabel ?? null;
+        popoverElement.hideText = this.#popoverHideText ?? null;
+        popoverElement.hideImageSrc = this.#popoverHideImageSrc ?? null;
         popoverElement.insertAdjacentHTML('afterbegin', this.#footnoteElement.innerHTML);
-        for (const element of popoverElement.querySelectorAll('[id]')) {
-            /* コピー元の HTML 中に id 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
-            element.removeAttribute('id');
-        }
-        popoverElement.addEventListener('close', this.#popoverCloseEventListener, { passive: true });
+        document.body.appendChild(popoverElement);
         popoverElement.addEventListener('mouseenter', () => {
             clearTimeout(this.#mouseleaveTimeoutId);
             this.#mouseenterTimeoutId = setTimeout(() => {
                 this.#show();
-            }, this.#popoverMouseenterDelay);
+            }, this.#mouseenterDelay);
         }, { passive: true });
         popoverElement.addEventListener('mouseleave', () => {
             clearTimeout(this.#mouseenterTimeoutId);
             this.#mouseleaveTimeoutId = setTimeout(() => {
-                this.#popoverElement.dispatchEvent(new Event('close'));
-            }, this.#popoverMouseleaveDelay);
+                this.#hide();
+            }, this.#mouseleaveDelay);
         }, { passive: true });
-        popoverWrapElement.appendChild(popoverElement);
-        const formElement = document.createElement('form');
-        formElement.method = 'dialog';
-        popoverElement.appendChild(formElement);
-        const closeButtonElement = document.createElement('button');
-        if (this.#popoverCloseImageSrc === undefined) {
-            closeButtonElement.textContent = this.#popoverCloseText;
-        }
-        else {
-            const closeButtonImageElement = document.createElement('img');
-            closeButtonImageElement.src = this.#popoverCloseImageSrc;
-            closeButtonImageElement.alt = this.#popoverCloseText;
-            closeButtonElement.appendChild(closeButtonImageElement);
-        }
-        formElement.appendChild(closeButtonElement);
-        /* 循環フォーカス */
-        const firstFocusableElement = document.createElement('span');
-        firstFocusableElement.tabIndex = 0;
-        firstFocusableElement.addEventListener('focus', () => {
-            closeButtonElement.focus();
-        }, { passive: true });
-        popoverWrapElement.insertAdjacentElement('afterbegin', firstFocusableElement);
-        const lastFocusableElement = document.createElement('span');
-        lastFocusableElement.tabIndex = 0;
-        lastFocusableElement.addEventListener('focus', () => {
-            popoverElement.focus();
-        }, { passive: true });
-        popoverWrapElement.insertAdjacentElement('beforeend', lastFocusableElement);
     }
     /**
      * ポップオーバーを表示する
-     *
-     * @param options - オプション
-     * @param options.focus - ポップオーバーにフォーカスを行うか
      */
-    #show(options = { focus: false }) {
+    #show() {
         const popoverElement = this.#popoverElement;
         if (!popoverElement.isConnected) {
             /* 初回表示時はポップオーバーの生成を行う */
@@ -209,26 +132,38 @@ export default class {
         }
         const triggerRect = this.#popoverTriggerElement.getBoundingClientRect();
         /* ポップオーバーの上位置を設定（トリガー要素の下端を基準にする） */
+        popoverElement.style.width = 'auto';
         popoverElement.style.top = `${String(Math.round(triggerRect.bottom) + window.pageYOffset)}px`;
+        popoverElement.style.right = 'auto';
+        popoverElement.style.left = 'auto';
         /* ポップオーバーを表示 */
-        this.#popoverWrapElement.hidden = false;
-        popoverElement.show();
-        if (options.focus) {
-            popoverElement.focus(); // TODO: 将来的には show() のパラメーターで指定できるようになる? https://github.com/whatwg/html/wiki/dialog--initial-focus,-a-proposal#initial-dialog-focus-logic
-        }
-        document.addEventListener('keydown', this.#popoverKeydownEventListener);
-        this.#popoverTriggerElement.setAttribute('aria-expanded', 'true');
+        popoverElement.dispatchEvent(new CustomEvent('toggle', {
+            detail: {
+                newState: 'open',
+            },
+        }));
         /* ポップオーバーの左右位置を設定（トリガー要素の左端を基準にする） */
         const documentWidth = document.documentElement.offsetWidth;
-        const popoverWidth = popoverElement.getBoundingClientRect().width;
-        popoverElement.style.left = 'auto';
-        popoverElement.style.right = 'auto';
-        if (documentWidth - triggerRect.left < popoverWidth) {
+        const popoverWidth = popoverElement.width;
+        const triggerRectLeft = triggerRect.left;
+        popoverElement.style.width = `${String(popoverWidth)}px`;
+        if (documentWidth - triggerRectLeft < popoverWidth) {
             popoverElement.style.right = '0';
         }
         else {
-            popoverElement.style.left = `${String(Math.round(triggerRect.left))}px`;
+            popoverElement.style.left = `${String(triggerRectLeft)}px`;
         }
+    }
+    /**
+     * ポップオーバーを非表示にする
+     */
+    #hide() {
+        const popoverElement = this.#popoverElement;
+        popoverElement.dispatchEvent(new CustomEvent('toggle', {
+            detail: {
+                newState: 'closed',
+            },
+        }));
     }
 }
 //# sourceMappingURL=FootnoteReferencePopover.js.map

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -21,7 +21,7 @@ export default class {
     constructor(thisElement) {
         this.#popoverTriggerElement = thisElement;
         const { href } = thisElement;
-        const { popoverLabel, popoverClass, popoverCloseText: popoverHideText, popoverCloseImageSrc: popoverHideImageSrc, mouseenterDelay, mouseleaveDelay, } = thisElement.dataset;
+        const { popoverLabel, popoverClass, popoverHideText, popoverHideImageSrc, mouseenterDelay, mouseleaveDelay, } = thisElement.dataset;
         if (href === '') {
             throw new Error('Attribute: `href` is not set.');
         }

--- a/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
+++ b/packages/footnote-reference-popover/dist/FootnoteReferencePopover.js
@@ -21,7 +21,7 @@ export default class {
     constructor(thisElement) {
         this.#popoverTriggerElement = thisElement;
         const { href } = thisElement;
-        const { popoverLabel, popoverClass, popoverCloseText: popoverHideText, popoverCloseImageSrc: popoverHideImageSrc, popoverMouseenterDelay: mouseenterDelay, popoverMouseleaveDelay: mouseleaveDelay, } = thisElement.dataset;
+        const { popoverLabel, popoverClass, popoverCloseText: popoverHideText, popoverCloseImageSrc: popoverHideImageSrc, mouseenterDelay, mouseleaveDelay, } = thisElement.dataset;
         if (href === '') {
             throw new Error('Attribute: `href` is not set.');
         }

--- a/packages/footnote-reference-popover/src/CustomElementPopover.ts
+++ b/packages/footnote-reference-popover/src/CustomElementPopover.ts
@@ -1,0 +1,241 @@
+/**
+ * Popover
+ */
+export default class CustomElementPopover extends HTMLElement {
+	readonly #popoverElement: HTMLDialogElement;
+
+	readonly #hideButtonElement: HTMLButtonElement;
+
+	readonly #firstFocusableElement: HTMLElement;
+
+	readonly #lastFocusableElement: HTMLElement;
+
+	#hideText = 'Close';
+
+	#hideImageSrc: string | null = null;
+
+	readonly #toggleEventListener: (ev: CustomEvent) => void;
+
+	readonly #keydownEventListener: (ev: KeyboardEvent) => void;
+
+	readonly #firstFocusableFocusEventListener: () => void;
+
+	readonly #lastFocusableFocusEventListener: () => void;
+
+	static get observedAttributes(): string[] {
+		return ['label', 'hide-text', 'hide-image-src'];
+	}
+
+	constructor() {
+		super();
+
+		const cssString = `
+			:host {
+				position: absolute;
+			}
+
+			[part="popover"] {
+				position: static;
+				contain: layout;
+				margin: 0;
+			}
+
+			[part="hide-button"] > img {
+				display: block;
+			}
+		`;
+
+		const shadow = this.attachShadow({ mode: 'open' });
+		shadow.innerHTML = `
+			<span id="first-focusable" tabindex="0"></span>
+			<dialog part="popover" autofocus="">
+				<slot></slot>
+				<form method="dialog">
+					<button part="hide-button"></button>
+				</form>
+			</dialog>
+			<span id="last-focusable" tabindex="0"></span>
+		`;
+
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		if (shadow.adoptedStyleSheets !== undefined) {
+			const cssStyleSheet = new CSSStyleSheet();
+			cssStyleSheet.replaceSync(cssString);
+
+			shadow.adoptedStyleSheets = [cssStyleSheet];
+		} else {
+			/* adoptedStyleSheets 未対応環境 */
+			shadow.innerHTML += `<style>${cssString}</style>`;
+		}
+
+		const shadowRoot = this.shadowRoot!;
+		this.#popoverElement = shadowRoot.querySelector('[part="popover"]')!;
+		this.#hideButtonElement = shadowRoot.querySelector('[part="hide-button"]')!;
+		this.#firstFocusableElement = shadowRoot.getElementById('first-focusable')!;
+		this.#lastFocusableElement = shadowRoot.getElementById('last-focusable')!;
+
+		this.#hideButtonElement.textContent = this.#hideText;
+
+		this.#toggleEventListener = this.#toggleEvent.bind(this);
+		this.#keydownEventListener = this.#keydownEvent.bind(this);
+		this.#firstFocusableFocusEventListener = this.#firstFocusableFocusEvent.bind(this);
+		this.#lastFocusableFocusEventListener = this.#lastFocusableFocusEvent.bind(this);
+	}
+
+	connectedCallback(): void {
+		this.hidden = true;
+
+		/* コピー元の HTML 中に id 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
+		for (const element of this.shadowRoot!.host.querySelectorAll('[id]')) {
+			element.removeAttribute('id');
+		}
+
+		/* ポップオーバー状態変化 */
+		this.addEventListener('toggle', this.#toggleEventListener as (ev: Event) => void, { passive: true });
+
+		/* 循環フォーカス */
+		this.#firstFocusableElement.addEventListener('focus', this.#firstFocusableFocusEventListener, { passive: true });
+		this.#lastFocusableElement.addEventListener('focus', this.#lastFocusableFocusEventListener, { passive: true });
+	}
+
+	disconnectedCallback(): void {
+		/* ポップオーバー状態変化 */
+		this.removeEventListener('toggle', this.#toggleEventListener as (ev: Event) => void);
+
+		/* 循環フォーカス */
+		this.#firstFocusableElement.removeEventListener('focus', this.#firstFocusableFocusEventListener);
+		this.#lastFocusableElement.removeEventListener('focus', this.#lastFocusableFocusEventListener);
+	}
+
+	attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+		switch (name) {
+			case 'label': {
+				this.label = newValue;
+				break;
+			}
+			case 'hide-text': {
+				this.hideText = newValue;
+				break;
+			}
+			case 'hide-image-src': {
+				this.hideImageSrc = newValue;
+				break;
+			}
+			default:
+		}
+	}
+
+	get label(): string | null {
+		return this.#popoverElement.ariaLabel;
+	}
+
+	set label(value: string | null) {
+		this.#popoverElement.ariaLabel = value;
+	}
+
+	get hideText(): string | null {
+		return this.#hideText;
+	}
+
+	set hideText(value: string | null) {
+		if (value === null) {
+			return;
+		}
+
+		this.#hideText = value;
+
+		this.#hideButtonElement.textContent = value;
+	}
+
+	get hideImageSrc(): string | null {
+		return this.#hideImageSrc;
+	}
+
+	set hideImageSrc(value: string | null) {
+		this.#hideImageSrc = value;
+
+		if (value === null) {
+			this.#hideButtonElement.textContent = this.#hideText;
+			return;
+		}
+
+		const newImageElement = document.createElement('img');
+		newImageElement.src = value;
+		newImageElement.alt = this.#hideText;
+
+		this.#hideButtonElement.textContent = '';
+		this.#hideButtonElement.appendChild(newImageElement);
+	}
+
+	get width(): number {
+		return this.#popoverElement.getBoundingClientRect().width;
+	}
+
+	/**
+	 * ポップオーバーの表示／非表示状態が変化したの処理
+	 *
+	 * @param ev - CustomEvent
+	 */
+	#toggleEvent(ev: CustomEvent): void {
+		switch (ev.detail.newState) {
+			case 'open': {
+				this.hidden = false;
+
+				this.#popoverElement.show();
+
+				document.addEventListener('keydown', this.#keydownEventListener);
+
+				break;
+			}
+			case 'closed': {
+				this.hidden = true;
+
+				this.#popoverElement.close();
+
+				document.removeEventListener('keydown', this.#keydownEventListener);
+
+				break;
+			}
+			default: {
+				throw new Error('The value of `newState` must be either `open` or `closed`.');
+			}
+		}
+	}
+
+	/**
+	 * popover `keydown` event
+	 *
+	 * @param ev - KeyboardEvent
+	 */
+	#keydownEvent(ev: KeyboardEvent): void {
+		switch (ev.key) {
+			case 'Escape': {
+				ev.preventDefault();
+
+				this.dispatchEvent(
+					new CustomEvent('toggle', {
+						detail: {
+							newState: 'closed',
+						},
+					}),
+				);
+				break;
+			}
+			default:
+		}
+	}
+
+	/**
+	 * 最初の循環フォーカス要素にフォーカスされたときの処理
+	 */
+	#firstFocusableFocusEvent(): void {
+		this.#hideButtonElement.focus();
+	}
+
+	/**
+	 * 最後の循環フォーカス要素にフォーカスされたときの処理
+	 */
+	#lastFocusableFocusEvent(): void {
+		this.#popoverElement.focus();
+	}
+}

--- a/packages/footnote-reference-popover/src/CustomElementPopover.ts
+++ b/packages/footnote-reference-popover/src/CustomElementPopover.ts
@@ -68,11 +68,10 @@ export default class CustomElementPopover extends HTMLElement {
 			shadow.innerHTML += `<style>${cssString}</style>`;
 		}
 
-		const shadowRoot = this.shadowRoot!;
-		this.#popoverElement = shadowRoot.querySelector('[part="popover"]')!;
-		this.#hideButtonElement = shadowRoot.querySelector('[part="hide-button"]')!;
-		this.#firstFocusableElement = shadowRoot.getElementById('first-focusable')!;
-		this.#lastFocusableElement = shadowRoot.getElementById('last-focusable')!;
+		this.#popoverElement = shadow.querySelector('[part="popover"]')!;
+		this.#hideButtonElement = shadow.querySelector('[part="hide-button"]')!;
+		this.#firstFocusableElement = shadow.getElementById('first-focusable')!;
+		this.#lastFocusableElement = shadow.getElementById('last-focusable')!;
 
 		this.#hideButtonElement.textContent = this.#hideText;
 
@@ -86,8 +85,11 @@ export default class CustomElementPopover extends HTMLElement {
 		this.hidden = true;
 
 		/* コピー元の HTML 中に id 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
-		for (const element of this.shadowRoot!.host.querySelectorAll('[id]')) {
-			element.removeAttribute('id');
+		const hostElement = this.shadowRoot?.host;
+		if (hostElement !== undefined) {
+			for (const element of hostElement.querySelectorAll('[id]')) {
+				element.removeAttribute('id');
+			}
 		}
 
 		/* ポップオーバー状態変化 */

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -28,6 +28,8 @@ export default class {
 
 	#mouseleaveTimeoutId?: NodeJS.Timeout; // ポップオーバーを非表示にする際のタイマーの識別 ID（`clearTimeout()` で使用）
 
+	#preloadProcessed = false; // `<link rel="preload" as="image" />` の生成処理を実行したかどうか
+
 	/**
 	 * @param thisElement - Target element
 	 */
@@ -35,14 +37,7 @@ export default class {
 		this.#popoverTriggerElement = thisElement;
 
 		const { href } = thisElement;
-		const {
-			popoverLabel,
-			popoverClass,
-			popoverHideText,
-			popoverHideImageSrc,
-			mouseenterDelay,
-			mouseleaveDelay,
-		} = thisElement.dataset;
+		const { popoverLabel, popoverClass, popoverHideText, popoverHideImageSrc, mouseenterDelay, mouseleaveDelay } = thisElement.dataset;
 
 		if (href === '') {
 			throw new Error('Attribute: `href` is not set.');
@@ -78,25 +73,6 @@ export default class {
 		thisElement.addEventListener('click', this.#clickEvent);
 		thisElement.addEventListener('mouseenter', this.#mouseEnterEvent, { passive: true });
 		thisElement.addEventListener('mouseleave', this.#mouseLeaveEvent, { passive: true });
-
-		/* Image preload */
-		if (
-			popoverHideImageSrc !== undefined &&
-			!popoverHideImageSrc.trimStart().startsWith('data:') &&
-			document.querySelector(`link[rel="preload"][href="${popoverHideImageSrc}"]`) === null
-		) {
-			const preloadElement = document.createElement('link');
-			preloadElement.rel = 'preload';
-			preloadElement.as = 'image';
-			preloadElement.href = popoverHideImageSrc;
-
-			const alreadyHeadLinkElements = document.head.querySelectorAll('link');
-			if (alreadyHeadLinkElements.length === 0) {
-				document.head.appendChild(preloadElement);
-			} else {
-				[...alreadyHeadLinkElements].at(-1)?.insertAdjacentElement('afterend', preloadElement);
-			}
-		}
 	}
 
 	/**
@@ -117,6 +93,8 @@ export default class {
 	 */
 	#mouseEnterEvent = (): void => {
 		clearTimeout(this.#mouseleaveTimeoutId);
+
+		this.#imagePreloadElementCreate();
 
 		this.#mouseenterTimeoutId = setTimeout((): void => {
 			this.#show();
@@ -226,5 +204,34 @@ export default class {
 				},
 			}),
 		);
+	}
+
+	/**
+	 * `<link rel="preload" as="image" />` を生成する
+	 */
+	#imagePreloadElementCreate(): void {
+		if (this.#preloadProcessed) {
+			/* 生成処理は1回のみ */
+			return;
+		}
+		this.#preloadProcessed = true;
+
+		const popoverHideImageSrc = this.#popoverHideImageSrc;
+
+		if (popoverHideImageSrc !== undefined && !popoverHideImageSrc.trimStart().startsWith('data:')) {
+			const parentElement = document.head;
+
+			const preloadElement = document.createElement('link');
+			preloadElement.rel = 'preload';
+			preloadElement.as = 'image';
+			preloadElement.href = popoverHideImageSrc;
+
+			const alreadyHeadLinkElements = parentElement.querySelectorAll('link');
+			if (alreadyHeadLinkElements.length === 0) {
+				parentElement.appendChild(preloadElement);
+			} else {
+				[...alreadyHeadLinkElements].at(-1)?.insertAdjacentElement('afterend', preloadElement);
+			}
+		}
 	}
 }

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -38,8 +38,8 @@ export default class {
 		const {
 			popoverLabel,
 			popoverClass,
-			popoverCloseText: popoverHideText,
-			popoverCloseImageSrc: popoverHideImageSrc,
+			popoverHideText,
+			popoverHideImageSrc,
 			mouseenterDelay,
 			mouseleaveDelay,
 		} = thisElement.dataset;

--- a/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/FootnoteReferencePopover.ts
@@ -40,8 +40,8 @@ export default class {
 			popoverClass,
 			popoverCloseText: popoverHideText,
 			popoverCloseImageSrc: popoverHideImageSrc,
-			popoverMouseenterDelay: mouseenterDelay,
-			popoverMouseleaveDelay: mouseleaveDelay,
+			mouseenterDelay,
+			mouseleaveDelay,
 		} = thisElement.dataset;
 
 		if (href === '') {

--- a/packages/footnote-reference-popover/tsconfig.json
+++ b/packages/footnote-reference-popover/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src/*.ts"],
+	"include": ["src/*.ts", "../../@types/lib.dom.d.ts"],
 	"compilerOptions": {
 		/* Emit */
 		"outDir": "dist"


### PR DESCRIPTION
In addition, the following changes were made.

- Rename `data-popover-close-*` attribute to `data-popover-hide-*`.
- Rename `data-popover-mouse*-delay` attribute to `data-mouse*-delay`.
- Changed `<link rel="preload" as="image" />` insertion timing to trigger element hover instead of page load.

