### PR TITLE
Changed the firing of the overlay close process from `unload` to `beforeunload`

### DIFF
--- a/packages/form-submit-overlay/src/FormSubmitOverlay.test.ts
+++ b/packages/form-submit-overlay/src/FormSubmitOverlay.test.ts
@@ -35,14 +35,14 @@ describe('event', () => {
 		spy.mockRestore();
 	});
 
-	test('unload', () => {
+	test('beforeunload', () => {
 		const element = document.querySelector('form')!;
 		const dialogElement = document.querySelector('dialog')!;
 		const spy = jest.spyOn(dialogElement, 'close');
 
 		new FormSubmitOverlay(element);
 
-		window.dispatchEvent(new Event('unload'));
+		window.dispatchEvent(new Event('beforeunload'));
 
 		expect(spy).toHaveBeenCalled();
 

--- a/packages/form-submit-overlay/src/FormSubmitOverlay.ts
+++ b/packages/form-submit-overlay/src/FormSubmitOverlay.ts
@@ -15,7 +15,7 @@ export default class {
 		this.#overlayElement = new Overlay(overlayedByAttribute);
 
 		thisElement.addEventListener('submit', this.#submitEvent.bind(this), { passive: true });
-		window.addEventListener('unload', this.#windowUnloadEvent.bind(this), { passive: true });
+		window.addEventListener('beforeunload', this.#windowBeforeUnloadEvent.bind(this), { passive: true });
 	}
 
 	/**
@@ -26,9 +26,9 @@ export default class {
 	}
 
 	/**
-	 * window - unload の処理
+	 * window - beforeunload の処理
 	 */
-	#windowUnloadEvent(): void {
+	#windowBeforeUnloadEvent(): void {
 		this.#overlayElement.element.close();
 	}
 }


### PR DESCRIPTION
Fixed a bug where canceling the `beforeunload` event while using `@w0s/form-before-unload-confirm` caused the overlay to remain displayed.