### PR TITLE
skypack.dev → esm.run

### DIFF
--- a/packages/closest-html-page/demo/index.html
+++ b/packages/closest-html-page/demo/index.html
@@ -61,7 +61,7 @@
 			{
 				"imports": {
 					"@w0s/closest-html-page": "../dist/index.js",
-					"whatwg-mimetype": "https://cdn.skypack.dev/whatwg-mimetype@4.0.0"
+					"whatwg-mimetype": "https://esm.run/whatwg-mimetype@4.0.0"
 				}
 			}
 		</script>

--- a/packages/details-animation/demo/index.html
+++ b/packages/details-animation/demo/index.html
@@ -77,8 +77,8 @@
 			{
 				"imports": {
 					"@w0s/details-animation": "../dist/index.js",
-					"@w0s/shadow-append-css": "https://cdn.skypack.dev/@w0s/shadow-append-css@1.1.2",
-					"@w0s/writing-mode": "https://cdn.skypack.dev/@w0s/writing-mode@1.1.1"
+					"@w0s/shadow-append-css": "https://esm.run/@w0s/shadow-append-css@1.1.2",
+					"@w0s/writing-mode": "https://esm.run/@w0s/writing-mode@1.1.1"
 				}
 			}
 		</script>

--- a/packages/footnote-reference-popover/demo/index.html
+++ b/packages/footnote-reference-popover/demo/index.html
@@ -51,7 +51,7 @@
 			{
 				"imports": {
 					"@w0s/footnote-reference-popover": "../dist/index.js",
-					"@w0s/shadow-append-css": "https://cdn.skypack.dev/@w0s/shadow-append-css@1.1.2"
+					"@w0s/shadow-append-css": "https://esm.run/@w0s/shadow-append-css@1.1.2"
 				}
 			}
 		</script>

--- a/packages/input-file-preview/demo/index.html
+++ b/packages/input-file-preview/demo/index.html
@@ -40,8 +40,8 @@
 			{
 				"imports": {
 					"@w0s/input-file-preview": "../dist/index.js",
-					"@w0s/html-escape": "https://cdn.skypack.dev/@w0s/html-escape@4.0.2",
-					"whatwg-mimetype": "https://cdn.skypack.dev/whatwg-mimetype@4.0.0"
+					"@w0s/html-escape": "https://esm.run/@w0s/html-escape@4.0.2",
+					"whatwg-mimetype": "https://esm.run/whatwg-mimetype@4.0.0"
 				}
 			}
 		</script>

--- a/packages/input-isbn/demo/index.html
+++ b/packages/input-isbn/demo/index.html
@@ -13,7 +13,7 @@
 			{
 				"imports": {
 					"@w0s/input-isbn": "../dist/index.js",
-					"@w0s/isbn-verify": "https://cdn.skypack.dev/@w0s/isbn-verify@3.1.2"
+					"@w0s/isbn-verify": "https://esm.run/@w0s/isbn-verify@3.1.2"
 				}
 			}
 		</script>

--- a/packages/input-switch/demo/index.html
+++ b/packages/input-switch/demo/index.html
@@ -37,7 +37,7 @@
 			{
 				"imports": {
 					"@w0s/input-switch": "../dist/index.js",
-					"@w0s/shadow-append-css": "https://cdn.skypack.dev/@w0s/shadow-append-css@1.1.2"
+					"@w0s/shadow-append-css": "https://esm.run/@w0s/shadow-append-css@1.1.2"
 				}
 			}
 		</script>

--- a/packages/tab/demo/index.html
+++ b/packages/tab/demo/index.html
@@ -51,7 +51,7 @@
 			{
 				"imports": {
 					"@w0s/tab": "../dist/index.js",
-					"@w0s/shadow-append-css": "https://cdn.skypack.dev/@w0s/shadow-append-css@1.1.2"
+					"@w0s/shadow-append-css": "https://esm.run/@w0s/shadow-append-css@1.1.2"
 				}
 			}
 		</script>

--- a/packages/table-cell-ditto/demo/index.html
+++ b/packages/table-cell-ditto/demo/index.html
@@ -40,7 +40,7 @@
 			{
 				"imports": {
 					"@w0s/table-cell-ditto": "../dist/index.js",
-					"text-metrics": "https://cdn.skypack.dev/text-metrics@4.0.1"
+					"text-metrics": "https://esm.run/text-metrics@4.0.1"
 				}
 			}
 		</script>

--- a/packages/textarea-auto-size/demo/index.html
+++ b/packages/textarea-auto-size/demo/index.html
@@ -13,7 +13,7 @@
 			{
 				"imports": {
 					"@w0s/textarea-auto-size": "../dist/index.js",
-					"@w0s/writing-mode": "https://cdn.skypack.dev/@w0s/writing-mode@1.1.1"
+					"@w0s/writing-mode": "https://esm.run/@w0s/writing-mode@1.1.1"
 				}
 			}
 		</script>


### PR DESCRIPTION
#173 で skypack.dev を利用することにしたが、これは private メソッドに対応していない。

例えば https://cdn.skypack.dev/@w0s/isbn-verify は以下のエラーになる。

```javascript
/*
 * [Package Error] "@w0s/isbn-verify@v3.1.2" could not be built. 
 *
 *   [1/5] Verifying package is valid…
 *   [2/5] Installing dependencies from npm…
 *   [3/5] Building package using esinstall…
 *   Running esinstall...
 *   Failed to load node_modules/@w0s/isbn-verify/dist/ISBN.js
 *     Unexpected token (89:4) in @w0s/isbn-verify/dist/ISBN.js
 *   Install failed.
 *   Install failed.
 *
 * How to fix:
 *   - If you believe this to be an error in Skypack, file an issue here: https://github.com/skypackjs/skypack-cdn/issues
 *   - If you believe this to be an issue in the package, share this URL with the package authors to help them debug & fix.
 *   - Use https://skypack.dev/ to find a web-friendly alternative to find another package.
 */

console.warn("[Package Error] \"@w0s/isbn-verify@v3.1.2\" could not be built. \n[1/5] Verifying package is valid…\n[2/5] Installing dependencies from npm…\n[3/5] Building package using esinstall…\nRunning esinstall...\nFailed to load node_modules/@w0s/isbn-verify/dist/ISBN.js\n  Unexpected token (89:4) in @w0s/isbn-verify/dist/ISBN.js\nInstall failed.\nInstall failed.");
throw new Error("[Package Error] \"@w0s/isbn-verify@v3.1.2\" could not be built. ");
export default null;
```