### PR TITLE
[details-animation] Remove @w0s/shadow-append-css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11298,7 +11298,6 @@
 			"version": "6.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"@w0s/shadow-append-css": "^1.1.0",
 				"@w0s/writing-mode": "^1.1.1"
 			}
 		},

--- a/packages/details-animation/README.md
+++ b/packages/details-animation/README.md
@@ -9,6 +9,15 @@
 - Animation speed (`duration`) and easing effects (`easing`) can be customized.
 - In [`prefers-reduced-motion: reduce`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) environments, no animation is performed. (Version 4.2.0 or later)
 
+## Browser support
+
+Using the ShadowRoot: `adoptedStyleSheets`. ([Can I use...](https://caniuse.com/mdn-api_shadowroot_adoptedstylesheets))
+
+- Firefox 101+
+- Safari 16.4+
+- Chrome 73+
+- Edge 79+
+
 ## Demo
 
 - [Demo page](https://saekitominaga.github.io/js-library-browser/packages/details-animation/demo/)
@@ -20,7 +29,6 @@
   {
     "imports": {
       "@w0s/details-animation": "...",
-      "@w0s/shadow-append-css": "...",
       "@w0s/writing-mode": "..."
     }
   }
@@ -40,6 +48,8 @@
   <p>Contents text</p>
 </details>
 ```
+
+\* **`@w0s/shadow-append-css` is no longer required since version 7.0**
 
 ## HTML attributes
 

--- a/packages/details-animation/demo/index.html
+++ b/packages/details-animation/demo/index.html
@@ -77,7 +77,6 @@
 			{
 				"imports": {
 					"@w0s/details-animation": "../dist/index.js",
-					"@w0s/shadow-append-css": "https://esm.run/@w0s/shadow-append-css@1.1.2",
 					"@w0s/writing-mode": "https://esm.run/@w0s/writing-mode@1.1.1"
 				}
 			}

--- a/packages/details-animation/package.json
+++ b/packages/details-animation/package.json
@@ -38,7 +38,6 @@
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest dist/.+\\.test\\.js  -c ../../jest.config.mjs --roots packages/details-animation"
 	},
 	"dependencies": {
-		"@w0s/shadow-append-css": "^1.1.0",
 		"@w0s/writing-mode": "^1.1.1"
 	},
 	"publishConfig": {

--- a/packages/details-animation/src/custom-element/DetailsContent.ts
+++ b/packages/details-animation/src/custom-element/DetailsContent.ts
@@ -1,4 +1,3 @@
-import shadowAppendCss from '@w0s/shadow-append-css';
 import WritingMode from '@w0s/writing-mode';
 import Duration from '../attribute/Duration.ts';
 import Easing from '../attribute/Easing.ts';
@@ -48,7 +47,9 @@ export default class CustomElementDetailsContent extends HTMLElement {
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		'setHTMLUnsafe' in shadow ? shadow.setHTMLUnsafe(htmlString) : ((shadow as ShadowRoot).innerHTML = htmlString);
 
-		shadowAppendCss(shadow, cssString);
+		const css = new CSSStyleSheet();
+		css.replaceSync(cssString);
+		shadow.adoptedStyleSheets.push(css);
 	}
 
 	connectedCallback(): void {


### PR DESCRIPTION
Safari 16.3 and earlier versions are no longer supported.